### PR TITLE
fix non-ASCII space character

### DIFF
--- a/R/ggcr_model.R
+++ b/R/ggcr_model.R
@@ -28,7 +28,7 @@ for (i in 1:nind){  # for each unit
         
         ## OBSERVATION EQUATIONS ##
 		# draw Obs[i,j+1] given st[i,j+1]
-		mydat[i,j+1]~ dcat(c(p[i,j],1-p[i,j])*equals(st[i,j+1],1)+ c(0,1)*equals(st[i,j+1],2))
+		mydat[i,j+1]~ dcat(c(p[i,j],1-p[i,j])*equals(st[i,j+1],1)+ c(0,1)*equals(st[i,j+1],2))
 		
 		# p[i,j] is detection prob at j+1
 		logit(p[i,j]) <- psi + eta[j]  #same detection for all units with time random effect.


### PR DESCRIPTION
one of the model files had a non-ASCII space that prevented installation on Ubuntu (locale information below). 

```
locale:
 [1] LC_CTYPE=en_CA.UTF8       LC_NUMERIC=C             
 [3] LC_TIME=en_CA.UTF8        LC_COLLATE=en_CA.UTF8    
 [5] LC_MONETARY=en_CA.UTF8    LC_MESSAGES=en_CA.UTF8   
 [7] LC_PAPER=en_CA.UTF8       LC_NAME=C                
 [9] LC_ADDRESS=C              LC_TELEPHONE=C           
[11] LC_MEASUREMENT=en_CA.UTF8 LC_IDENTIFICATION=C   
```